### PR TITLE
Minor corrections (stat, service uri status code, and docs) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ springBoot {
 
 ```
 
+Please, see more examples in the article [Installing Spring Boot applications](https://docs.spring.io/spring-boot/docs/current/reference/html/deployment-install.html).
 
 Role Variables
 --------------
@@ -50,6 +51,9 @@ spring_boot_application_id: "springbootapplication"
 
 # the HTTP port the Spring Boot application should listen to
 spring_boot_http_port: 8080
+
+# the Spring Boot application file to copy from
+spring_boot_file_source: "/tmp/springbootapplication-1.0.0.jar"
 ```
 
 Dependencies
@@ -70,6 +74,15 @@ roles:
   }
 ```
 
+To use on a remote environment (then it'll copy from a path on the server):
+
+```
+hosts: my_server
+roles:
+- { role: ansible-springboot-role, 
+    spring_boot_file_source: '/tmp/example-application.jar' 
+  }
+```
 License
 -------
 

--- a/meta/.galaxy_install_info
+++ b/meta/.galaxy_install_info
@@ -1,0 +1,1 @@
+{install_date: 'Sun Oct  1 22:39:08 2017', version: master}

--- a/tasks/copy_springboot_application.yml
+++ b/tasks/copy_springboot_application.yml
@@ -1,14 +1,19 @@
 - name: "check for spring boot application file"
-  stat: path={{ spring_boot_file_source }}
-  register: spring_boot_file
+  stat: 
+    path: "{{ spring_boot_file_source }}"
+  register: path
   ignore_errors: True
 
-- fail: msg="local spring boot file '{{ spring_boot_file_source }}' not found"
-  when: not spring_boot_file.stat.exists
+- debug:
+    msg: "{{ path }}"
+
+- fail:
+    msg: "local spring boot file '{{ spring_boot_file_source }}' not found"
+  when: not path.stat.exists
 
 - name: "copy spring boot file"
   command: cp {{ spring_boot_file_source }} {{ spring_boot_user_dir }}/{{ spring_boot_file }}
-  when: spring_boot_file.stat.exists
+  when: path.stat.exists
 
 - debug: msg="spring boot file '{{ spring_boot_file_source }}' not found"
-  when: not spring_boot_file.stat.exists
+  when: not path.stat.exists

--- a/tasks/copy_springboot_application.yml
+++ b/tasks/copy_springboot_application.yml
@@ -1,19 +1,16 @@
 - name: "check for spring boot application file"
   stat: 
     path: "{{ spring_boot_file_source }}"
-  register: path
+  register: spring_file
   ignore_errors: True
-
-- debug:
-    msg: "{{ path }}"
 
 - fail:
     msg: "local spring boot file '{{ spring_boot_file_source }}' not found"
-  when: not path.stat.exists
+  when: not spring_file.stat.exists
 
 - name: "copy spring boot file"
   command: cp {{ spring_boot_file_source }} {{ spring_boot_user_dir }}/{{ spring_boot_file }}
-  when: path.stat.exists
+  when: spring_file.stat.exists
 
 - debug: msg="spring boot file '{{ spring_boot_file_source }}' not found"
-  when: not path.stat.exists
+  when: not spring_file.stat.exists

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -65,13 +65,13 @@
   service: name={{ spring_boot_application_id }} enabled=yes
 
 - name: "start spring-boot service"
-  service: name={{ spring_boot_application_id }} state=restarted
+  service: name='{{ spring_boot_application_id }}' state=restarted
 
 - name: "wait for application to come up"
   uri:
     url: "http://127.0.0.1:{{spring_boot_http_port}}/"
-    status_code: 200
+    status_code: '200,404'
   register: result
-  until: result.status == 200
+  until: (result.status == 200) or (result.status == 404)
   retries: 60
   delay: 10


### PR DESCRIPTION
Hi!

Please allow me to send you this PR:

- The `stat` module wasn't able to validate the expression `spring_boot_file` with apparently no reason. Just changed to `path` and worked like a charm
- In the `wait for the application ...` task I've added the status code 404 in case the application doesn't have a default path on `/` root.
- Described a more detailed information on docs regarding Spring Boot service and differences between "local" and server copy.

Environment:

- Jenkins 2 with Pipeline plugin
- Host on CentOS 7
- Ansible 2.4.0.0
- Python  2.7.13

Many thanks for your role. Great job! Helped me a lot. Please, provide your feedback regarding my PR (if not accepted) so I may use it on my builds.

Cheers